### PR TITLE
Add network block device boot support to dispatcher

### DIFF
--- a/lava_dispatcher/deployment_data.py
+++ b/lava_dispatcher/deployment_data.py
@@ -220,3 +220,17 @@ debian_installer = deployment_data_dict({  # pylint: disable=invalid-name
     'lava_test_results_dir': '/lava-%s',
     'lava_test_shell_file': '~/.bashrc',
 })
+
+agl = deployment_data_dict({
+    'TESTER_PS1': "linaro-test [rc=$(echo \$?)]# ",
+    'TESTER_PS1_PATTERN': "linaro-test \[rc=(\d+)\]# ",
+    'TESTER_PS1_INCLUDES_RC': True,
+    'boot_cmds': 'boot_cmds_oe',
+
+    # for lava-test-shell
+    'distro': 'oe',
+    'lava_test_sh_cmd': '/bin/bash',
+    'lava_test_dir': '/home/root/lava-%s',
+    'lava_test_results_part_attr': 'root_part',
+    'lava_test_results_dir': '/home/root/lava-%s',
+})

--- a/lava_dispatcher/pipeline/actions/boot/__init__.py
+++ b/lava_dispatcher/pipeline/actions/boot/__init__.py
@@ -326,6 +326,7 @@ class BootloaderCommandOverlay(Action):
         self.use_bootscript = False
         self.lava_mac = None
         self.bootcommand = ''
+        self.ram_disk = None
 
     def validate(self):
         super(BootloaderCommandOverlay, self).validate()
@@ -366,12 +367,18 @@ class BootloaderCommandOverlay(Action):
         connection = super(BootloaderCommandOverlay, self).run(connection, max_end_time, args)
         ip_addr = dispatcher_ip(self.job.parameters['dispatcher'])
 
+        self.ram_disk = self.get_namespace_data(action='compress-ramdisk', label='file', key='ramdisk')
+        # most jobs substitute RAMDISK, so also use this for the initrd
+        if self.get_namespace_data(action='nbd-deploy', label='nbd', key='initrd'):
+            self.ram_disk = self.get_namespace_data(action='download-action', label='file', key='initrd')
+
         substitutions = {
             '{SERVER_IP}': ip_addr,
             '{PRESEED_CONFIG}': self.get_namespace_data(action='download-action', label='file', key='preseed'),
             '{PRESEED_LOCAL}': self.get_namespace_data(action='compress-ramdisk', label='file', key='preseed_local'),
             '{DTB}': self.get_namespace_data(action='download-action', label='file', key='dtb'),
-            '{RAMDISK}': self.get_namespace_data(action='compress-ramdisk', label='file', key='ramdisk'),
+            '{RAMDISK}': self.ram_disk,
+            '{INITRD}': self.ram_disk,
             '{KERNEL}': self.get_namespace_data(action='download-action', label='file', key='kernel'),
             '{LAVA_MAC}': self.lava_mac
         }
@@ -386,20 +393,29 @@ class BootloaderCommandOverlay(Action):
             self.logger.info("Using kernel file from prepare-kernel: %s", prepared_kernel)
             substitutions['{KERNEL}'] = prepared_kernel
         if self.bootcommand:
+            self.logger.debug("%s" % self.job.device['parameters'])
             kernel_addr = self.job.device['parameters'][self.bootcommand]['kernel']
             dtb_addr = self.job.device['parameters'][self.bootcommand]['dtb']
             ramdisk_addr = self.job.device['parameters'][self.bootcommand]['ramdisk']
 
             if not self.get_namespace_data(action='tftp-deploy', label='tftp', key='ramdisk') \
-                    and not self.get_namespace_data(action='download-action', label='file', key='ramdisk'):
+                    and not self.get_namespace_data(action='download-action', label='file', key='ramdisk') \
+                    and not self.get_namespace_data(action='download-action', label='file', key='initrd'):
                 ramdisk_addr = '-'
             add_header = self.job.device['actions']['deploy']['parameters'].get('add_header', None)
             if self.method == 'u-boot' and not add_header == "u-boot":
                 self.logger.debug("No u-boot header, not passing ramdisk to bootX cmd")
                 ramdisk_addr = '-'
 
-            substitutions['{BOOTX}'] = "%s %s %s %s" % (
-                self.bootcommand, kernel_addr, ramdisk_addr, dtb_addr)
+            if self.get_namespace_data(action='download-action', label='file', key='initrd'):
+                # no u-boot header, thus no embedded size, so we have to add it to the
+                # boot cmd with colon after the ramdisk
+                substitutions['{BOOTX}'] = "%s %s %s:%s %s" % (
+                    self.bootcommand, kernel_addr, ramdisk_addr, '${initrd_size}', dtb_addr)
+            else:
+                substitutions['{BOOTX}'] = "%s %s %s %s" % (
+                    self.bootcommand, kernel_addr, ramdisk_addr, dtb_addr)
+
             substitutions['{KERNEL_ADDR}'] = kernel_addr
             substitutions['{DTB_ADDR}'] = dtb_addr
             substitutions['{RAMDISK_ADDR}'] = ramdisk_addr
@@ -421,6 +437,12 @@ class BootloaderCommandOverlay(Action):
 
         substitutions['{ROOT}'] = self.get_namespace_data(action='uboot-from-media', label='uuid', key='root')  # UUID label, not a file
         substitutions['{ROOT_PART}'] = self.get_namespace_data(action='uboot-from-media', label='uuid', key='boot_part')
+
+        nbd_root = self.get_namespace_data(action='download-action', label='file', key='nbdroot')
+        if nbd_root:
+            substitutions['{NBDSERVERIP}'] = str(self.get_namespace_data(action='nbd-deploy', label='nbd', key='nbd_server_ip'))
+            substitutions['{NBDSERVERPORT}'] = str(self.get_namespace_data(action='nbd-deploy', label='nbd', key='nbd_server_port'))
+
         if self.use_bootscript:
             script = "/script.ipxe"
             bootscript = self.get_namespace_data(action='tftp-deploy', label='tftp', key='tftp_dir') + script

--- a/lava_dispatcher/pipeline/actions/deploy/download.py
+++ b/lava_dispatcher/pipeline/actions/deploy/download.py
@@ -351,7 +351,7 @@ class DownloadHandler(Action):  # pylint: disable=too-many-instance-attributes
             self.results = {'success': {'sha256': sha256sum}}
 
         # certain deployments need prefixes set
-        if self.parameters['to'] == 'tftp':
+        if self.parameters['to'] == 'tftp' or self.parameters['to'] == 'nbd':
             suffix = self.get_namespace_data(action='tftp-deploy', label='tftp',
                                              key='suffix')
             self.set_namespace_data(action='download-action', label='file', key=self.key,
@@ -363,6 +363,12 @@ class DownloadHandler(Action):  # pylint: disable=too-many-instance-attributes
                                     value=os.path.join(suffix, self.key, os.path.basename(fname)))
         else:
             self.set_namespace_data(action='download-action', label='file', key=self.key, value=fname)
+
+        # xnbd protocoll needs to know the location
+        nbdroot = self.get_namespace_data(action='download-action', label='file', key='nbdroot')
+        if 'lava-xnbd' in self.parameters and nbdroot:
+            self.parameters['lava-xnbd']['nbdroot'] = nbdroot
+
         self.results = {
             'label': self.key,
             'md5sum': str(self.get_namespace_data(

--- a/lava_dispatcher/pipeline/actions/deploy/nbd.py
+++ b/lava_dispatcher/pipeline/actions/deploy/nbd.py
@@ -1,0 +1,199 @@
+# Copyright (C) 2017 The Linux Foundation
+#
+# Author: Jan-Simon Moeller <jsmoeller@linuxfoundation.org>
+#
+# This file is part of LAVA Dispatcher.
+#
+# LAVA Dispatcher is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# LAVA Dispatcher is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along
+# with this program; if not, see <http://www.gnu.org/licenses>.
+
+# List just the subclasses supported for this base strategy
+# imported by the parser to populate the list of subclasses.
+
+import os
+import tempfile
+
+from lava_dispatcher.pipeline.action import Pipeline
+from lava_dispatcher.pipeline.logical import Deployment
+from lava_dispatcher.pipeline.actions.deploy import DeployAction
+from lava_dispatcher.pipeline.actions.deploy.download import DownloaderAction
+from lava_dispatcher.pipeline.utils.shell import infrastructure_error
+from lava_dispatcher.pipeline.utils.filesystem import tftpd_dir
+from lava_dispatcher.pipeline.utils.network import get_free_port
+from lava_dispatcher.pipeline.utils.network import dispatcher_ip
+from lava_dispatcher.pipeline.protocols.xnbd import XnbdProtocol
+from lava_dispatcher.pipeline.actions.deploy.overlay import OverlayAction
+
+
+def nbd_accept(device, parameters):
+    """
+    Each nbd deployment strategy uses these checks
+    as a base, then makes the final decision on the
+    style of nbd deployment.
+    """
+    if 'to' not in parameters:
+        return False
+    if parameters['to'] != 'nbd':
+        return False
+    if not device:
+        return False
+    if 'actions' not in device:
+        raise RuntimeError("Invalid device configuration")
+    if 'deploy' not in device['actions']:
+        return False
+    if 'methods' not in device['actions']['deploy']:
+        raise RuntimeError("Device misconfiguration")
+    return True
+
+
+class Nbd(Deployment):
+    """
+    Strategy class for a tftp+initrd+nbd based Deployment.
+    tftp is used for kernel/initrd/fdt. Rootfs over nbd (network block device).
+    Downloads the relevant parts, copies to the tftp location.
+    Limited to what the bootloader can deploy which means ramdisk or nfsrootfs.
+    rootfs deployments would format the device and create a single partition for the rootfs.
+    """
+
+    compatibility = 1
+
+    def __init__(self, parent, parameters):
+        super(Nbd, self).__init__(parent)
+        self.action = NbdAction()
+        self.action.section = self.action_type
+        self.action.job = self.job
+        parent.add_action(self.action, parameters)
+
+    @classmethod
+    def accepts(cls, device, parameters):
+        if not nbd_accept(device, parameters):
+            return False
+        if 'nbd' in device['actions']['deploy']['methods']:
+            return True
+        return False
+
+
+class NbdAction(DeployAction):  # pylint:disable=too-many-instance-attributes
+
+    def __init__(self):
+        super(NbdAction, self).__init__()
+        self.name = "nbd-deploy"
+        self.description = "download files and deploy for using tftp+initrd+nbd"
+        self.summary = "nbd deployment"
+        self.tftp_dir = None
+        self.nbd_ip = None
+        self.nbd_port = None
+
+    def validate(self):
+        super(NbdAction, self).validate()
+        if 'kernel' not in self.parameters:
+            self.errors = "%s needs a kernel to deploy" % self.name
+        if not self.valid:
+            return
+        if 'nbdroot' not in self.parameters:
+            self.errors = "NBD deployment needs a 'nbdroot' parameter"
+        if 'initrd' not in self.parameters:
+            self.errors = "NBD deployment needs an 'initrd' parameter"
+        # we cannot work with these when using nbd
+        if 'nfsrootfs' in self.parameters or 'nfs_url' in self.parameters:
+            self.errors = "nfsrootfs or nfs_url cannot be used with NBD deployment, use a e.g. ext3/4 filesystem as 'nbdroot=' parameter"
+        if 'ramdisk' in self.parameters:
+            self.errors = "ramdisk cannot be used with NBD deployment, use a e.g. ext3/4 filesystem as 'initrd' parameter"
+
+        if self.test_needs_deployment(self.parameters):
+            lava_test_results_base = self.parameters['deployment_data']['lava_test_results_dir']
+            lava_test_results_dir = lava_test_results_base % self.job.job_id
+            self.set_namespace_data(action='test', label='results', key='lava_test_results_dir', value=lava_test_results_dir)
+
+        # Extract the 3 last path elements. See action.mkdtemp()
+        suffix = os.path.join(*self.tftp_dir.split('/')[-2:])
+        self.set_namespace_data(action="tftp-deploy", label='tftp', key='suffix', value=suffix)
+        # we need tftp _and_ xnbd-server
+        self.errors = infrastructure_error('in.tftpd')
+        self.errors = infrastructure_error('xnbd-server')
+
+        # Check that the tmp directory is in the nbdd_dir or in /tmp for the
+        # unit tests
+        tftpd_directory = os.path.realpath(tftpd_dir())
+        tftp_dir = os.path.realpath(self.tftp_dir)
+        tmp_dir = tempfile.gettempdir()
+        if not tftp_dir.startswith(tftpd_directory) and \
+           not tftp_dir.startswith(tmp_dir):
+            self.errors = "tftpd directory is not configured correctly, see /etc/default/tftpd-hpa"
+
+    def populate(self, parameters):
+        self.tftp_dir = self.mkdtemp(override=tftpd_dir())
+        self.internal_pipeline = Pipeline(parent=self, job=self.job, parameters=parameters)
+        self.set_namespace_data(action=self.name, label='tftp', key='tftp_dir', value=self.tftp_dir, parameters=parameters)
+
+        for key in ['initrd', 'kernel', 'dtb', 'nbdroot']:
+            if key in parameters:
+                download = DownloaderAction(key, path=self.tftp_dir)
+                download.max_retries = 3  # overridden by failure_retry in the parameters, if set.
+                self.internal_pipeline.add_action(download)
+                if key == 'initrd':
+                    self.set_namespace_data(action="tftp-deploy", label='tftp', key='ramdisk', value=True, parameters=parameters)
+                    self.set_namespace_data(action=self.name, label='nbd', key='initrd', value=True, parameters=parameters)
+
+        # prepare overlay
+        self.internal_pipeline.add_action(OverlayAction())
+        # setup values for protocol and later steps
+        self.set_namespace_data(action=self.name, label='nbd', key='initrd', value=True, parameters=parameters)
+        # store in parameters for protocol 'xnbd' to tear-down xnbd-server
+        # and store in namespace for boot action
+        # ip
+        parameters['lava-xnbd'] = {}
+        self.nbd_ip = dispatcher_ip(self.job.parameters['dispatcher'])
+        parameters['lava-xnbd']['ip'] = self.nbd_ip
+        self.set_namespace_data(action=self.name, label='nbd', key='nbd_server_ip', value=self.nbd_ip, parameters=parameters)
+        # port
+        self.nbd_port = get_free_port(self.job.parameters['dispatcher'])
+        parameters['lava-xnbd']['port'] = self.nbd_port
+        self.set_namespace_data(action=self.name, label='nbd', key='nbd_server_port', value=self.nbd_port, parameters=parameters)
+        # handle XnbdAction next - bring-up xnbd-server
+        self.internal_pipeline.add_action(XnbdAction())
+
+
+class XnbdAction(DeployAction):
+
+    def __init__(self):
+        super(XnbdAction, self).__init__()
+        self.name = "xnbd-server-deploy"
+        self.description = "xnbd daemon"
+        self.summary = "xnbd daemon"
+        self.protocol = XnbdProtocol.name
+        self.nbd_server_port = None
+        self.nbd_server_ip = None
+
+    def validate(self):
+        pass
+
+    def run(self, connection, max_end_time, args=None):
+        connection = super(XnbdAction, self).run(connection, max_end_time, args)
+        self.logger.debug("%s: starting xnbd-server", self.name)
+        # pull from parameters - as previously set
+        self.nbd_server_port = self.parameters['lava-xnbd']['port']
+        self.nbd_server_ip = self.parameters['lava-xnbd']['ip']
+        self.nbd_root = self.parameters['lava-xnbd']['nbdroot']
+        self.logger.debug("NBD-IP: %s, NBD-PORT: %s, NBD-ROOT: %s" % (self.nbd_server_ip, self.nbd_server_port, self.nbd_root))
+        nbd_cmd = ['xnbd-server', '--logpath', '/tmp/xnbd.log.%s' % self.nbd_server_port,
+                   '--daemon', '--target', '--lport', '%s' % self.nbd_server_port,
+                   '%s/%s' % (os.path.realpath(tftpd_dir()),
+                              self.nbd_root)]
+        command_output = self.run_command(nbd_cmd, allow_fail=False)
+
+        if command_output and 'error' in command_output:
+            self.errors = infrastructure_error('xnbd-server: %s' % command_output)
+        self.logger.debug("%s: starting xnbd-server done", self.name)
+        return connection

--- a/lava_dispatcher/pipeline/actions/deploy/strategies.py
+++ b/lava_dispatcher/pipeline/actions/deploy/strategies.py
@@ -32,3 +32,4 @@ from lava_dispatcher.pipeline.actions.deploy.lxc import Lxc
 from lava_dispatcher.pipeline.actions.deploy.iso import DeployIso
 from lava_dispatcher.pipeline.actions.deploy.nfs import Nfs
 from lava_dispatcher.pipeline.actions.deploy.vemsd import VExpressMsd
+from lava_dispatcher.pipeline.actions.deploy.nbd import Nbd

--- a/lava_dispatcher/pipeline/devices/bbb-01.yaml
+++ b/lava_dispatcher/pipeline/devices/bbb-01.yaml
@@ -36,6 +36,10 @@ commands:
   power_off: /usr/bin/pduclient --daemon localhost --hostname pdu --command off --port 08
   power_on: /usr/bin/pduclient --daemon localhost --hostname pdu --command on --port 08
 
+protocols:
+  lava-xnbd:
+    port: auto
+
 constants:
   shutdown-message: "The system is going down for reboot NOW"
   boot-message: "Booting Linux"
@@ -53,6 +57,7 @@ actions:
       mkimage_arch: arm # string to pass to mkimage -A when adding UBoot headers
     methods:
       tftp:
+      nbd:
       usb:
       lxc:
       ssh:
@@ -121,6 +126,22 @@ actions:
           # Always quote the entire string if the command includes a colon to support correct YAML.
           - "setenv nfsargs 'setenv bootargs console=ttyO0,115200n8 root=/dev/nfs rw nfsroot={SERVER_IP}:{NFSROOTFS},tcp,hard,intr ip=dhcp'"
           - setenv bootcmd 'dhcp; setenv serverip {SERVER_IP}; run loadkernel; run loadinitrd; run loadfdt; run nfsargs; {BOOTX}'
+          - boot
+        nbd:
+          commands:
+          - setenv autoload no
+          - setenv verify no
+          - setenv initrd_high '0xffffffff'
+          - setenv fdt_high '0xffffffff'
+          - setenv kernel_addr_r '{KERNEL_ADDR}'
+          - setenv initrd_addr_r '{RAMDISK_ADDR}'
+          - setenv fdt_addr_r '{DTB_ADDR}'
+          - setenv loadkernel 'tftp {kernel_addr_r} {KERNEL}'
+          - setenv loadinitrd 'tftp {initrd_addr_r} {RAMDISK}; setenv initrd_size ${filesize}'
+          - setenv loadfdt 'tftp {fdt_addr_r} {DTB}'
+          # Always quote the entire string if the command includes a colon to support correct YAML.
+          - "setenv nbdargs 'setenv bootargs console=ttyO0,115200n8 ip=dhcp nbd.server={NBDSERVERIP} nbd.port={NBDSERVERPORT} root=/dev/ram0 ramdisk_size=16384 rootdelay=7'"
+          - setenv bootcmd 'dhcp; setenv serverip {SERVER_IP}; run loadkernel; run loadinitrd; run loadfdt; run nbdargs; {BOOTX}'
           - boot
         ramdisk:
           commands:

--- a/lava_dispatcher/pipeline/protocols/strategies.py
+++ b/lava_dispatcher/pipeline/protocols/strategies.py
@@ -23,3 +23,4 @@
 from lava_dispatcher.pipeline.protocols.multinode import MultinodeProtocol
 from lava_dispatcher.pipeline.protocols.lxc import LxcProtocol
 from lava_dispatcher.pipeline.protocols.vland import VlandProtocol
+from lava_dispatcher.pipeline.protocols.xnbd import XnbdProtocol

--- a/lava_dispatcher/pipeline/protocols/xnbd.py
+++ b/lava_dispatcher/pipeline/protocols/xnbd.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2017 The Linux Foundation
+#
+# Author: Jan-Simon Moeller <jsmoeller@linuxfoundation.org>
+#
+# This file is part of LAVA Dispatcher.
+#
+# LAVA Dispatcher is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# LAVA Dispatcher is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along
+# with this program; if not, see <http://www.gnu.org/licenses>.
+
+
+import pexpect
+import logging
+from lava_dispatcher.pipeline.connection import Protocol
+from lava_dispatcher.pipeline.action import (
+    Timeout,
+)
+from lava_dispatcher.pipeline.utils.shell import infrastructure_error
+from lava_dispatcher.pipeline.shell import ShellCommand
+from lava_dispatcher.pipeline.utils.constants import XNBD_SYSTEM_TIMEOUT
+
+
+class XnbdProtocol(Protocol):
+    """
+    Xnbd protocol (xnbd-server teardown)
+    """
+    name = "lava-xnbd"
+
+    def __init__(self, parameters, job_id):
+        super(XnbdProtocol, self).__init__(parameters, job_id)
+        # timeout in utils.constants, default 10000
+        self.system_timeout = Timeout('system', XNBD_SYSTEM_TIMEOUT)
+        self.logger = logging.getLogger('dispatcher')
+        self.parameters = parameters
+        self.port = None
+
+    @classmethod
+    def accepts(cls, parameters):
+        if 'protocols' not in parameters:
+            return False
+        if 'lava-xnbd' not in parameters['protocols']:
+            return False
+        return True
+
+    def set_up(self):
+        """
+        Called from the job at the start of the run step.
+        """
+
+        if 'port' not in self.parameters['protocols']['lava-xnbd']:
+            self.errors = ('No port set in parameters for lava-xnbd protocol!\nE.g.:\n protocols:\n  lava-xnbd:\n    port: auto \n')
+
+    def finalise_protocol(self, device=None):
+        """Called by Finalize action to power down and clean up the assigned
+        device.
+        """
+        # shutdown xnbd for the given device/job based in the port-number used
+        try:
+            self.logger.debug("%s cleanup", self.name)
+            self.port = self.parameters['protocols']['lava-xnbd']['port']
+            nbd_cmd = "pkill -f xnbd-server.*%s" % (self.port)
+            shell = ShellCommand("%s\n" % nbd_cmd, self.system_timeout,
+                                 logger=self.logger)
+            shell.expect(pexpect.EOF)
+        except Exception as e:
+            self.logger.debug(str(e))
+            self.logger.debug("xnbd-finalize-protocol failed, but continuing anyway.")

--- a/lava_dispatcher/pipeline/test/pipeline_refs/bbb-initrd-nbd.yaml
+++ b/lava_dispatcher/pipeline/test/pipeline_refs/bbb-initrd-nbd.yaml
@@ -1,0 +1,41 @@
+- class: actions.deploy.nbd.NbdAction
+  name: nbd-deploy
+  pipeline:
+  - class: actions.deploy.download.DownloaderAction
+    name: download-retry
+    pipeline:
+    - {class: actions.deploy.download.HttpDownloadAction, name: http-download}
+  - class: actions.deploy.download.DownloaderAction
+    name: download-retry
+    pipeline:
+    - {class: actions.deploy.download.HttpDownloadAction, name: http-download}
+  - class: actions.deploy.download.DownloaderAction
+    name: download-retry
+    pipeline:
+    - {class: actions.deploy.download.HttpDownloadAction, name: http-download}
+  - class: actions.deploy.download.DownloaderAction
+    name: download-retry
+    pipeline:
+    - {class: actions.deploy.download.HttpDownloadAction, name: http-download}
+  - {class: actions.deploy.overlay.OverlayAction, name: lava-overlay}
+  - {class: actions.deploy.nbd.XnbdAction, name: xnbd-server-deploy}
+- class: actions.boot.u_boot.UBootAction
+  name: uboot-action
+  pipeline:
+  - {class: actions.boot.u_boot.UBootSecondaryMedia, name: uboot-from-media}
+  - {class: actions.boot.BootloaderCommandOverlay, name: bootloader-overlay}
+  - {class: connections.serial.ConnectDevice, name: connect-device}
+  - class: actions.boot.u_boot.UBootRetry
+    name: uboot-retry
+    pipeline:
+    - class: power.ResetDevice
+      name: reset-device
+      pipeline:
+      - {class: power.PDUReboot, name: pdu-reboot}
+    - {class: actions.boot.u_boot.UBootInterrupt, name: u-boot-interrupt}
+    - {class: actions.boot.BootloaderCommandsAction, name: bootloader-commands}
+    - {class: actions.boot.AutoLoginAction, name: auto-login-action}
+- class: power.FinalizeAction
+  name: finalize
+  pipeline:
+  - {class: power.PowerOff, name: power-off}

--- a/lava_dispatcher/pipeline/test/sample_jobs/bbb-initrd-nbd.yaml
+++ b/lava_dispatcher/pipeline/test/sample_jobs/bbb-initrd-nbd.yaml
@@ -1,0 +1,41 @@
+device_type: beaglebone-black
+
+job_name: bbb-armhf-standard-initrd-nbd
+timeouts:
+  job:
+    minutes: 15
+  action:
+    minutes: 5
+  connection:
+    minutes: 2
+priority: medium
+visibility: public
+
+actions:
+- deploy:
+    timeout:
+      minutes: 4
+    to: nbd
+    kernel:
+      url: https://download.automotivelinux.org/AGL/snapshots/master/latest/beaglebone/deploy/images/beaglebone/zImage
+      type: zimage
+    initrd:
+      url: https://download.automotivelinux.org/AGL/snapshots/master/latest/beaglebone/deploy/images/beaglebone/initramfs-netboot-image-beaglebone.ext4.gz
+      allow_modify: false
+    nbdroot:
+      url: https://download.automotivelinux.org/AGL/snapshots/master/latest/beaglebone/deploy/images/beaglebone/agl-demo-platform-crosssdk-beaglebone.ext4.xz
+      compression: xz
+    os: agl
+    dtb:
+      url: https://download.automotivelinux.org/AGL/snapshots/master/latest/beaglebone/deploy/images/beaglebone/zImage-am335x-boneblack.dtb
+
+- boot:
+    method: u-boot
+    commands: nbd
+    auto_login:
+      login_prompt: 'login:'
+      username: root
+    prompts:
+    - 'root@beaglebone:'
+    timeout:
+      minutes: 4

--- a/lava_dispatcher/pipeline/utils/constants.py
+++ b/lava_dispatcher/pipeline/utils/constants.py
@@ -143,3 +143,12 @@ REBOOT_COMMAND_LIST = ['reboot', 'reboot -n', 'reboot -nf']
 
 # Default size limit for tftp in bytes (4Gb)
 TFTP_SIZE_LIMIT = 4 * 1024 * 1024 * 1024
+
+# XNBD server timeout (nbd deploy / xnbd protocol)
+XNBD_SYSTEM_TIMEOUT = 10000
+
+# XNBD port range min, default 55000
+XNBD_PORT_RANGE_MIN = 55000
+
+# XNBD port range max, default 56000
+XNBD_PORT_RANGE_MAX = 56000


### PR DESCRIPTION
Backport from upstream: https://review.linaro.org/#/c/17088/

This changeset implements boot with a network block device.
Initial steps are equal to tftp+nfs but instead of nfs this
method depends on an nbd-client started on the target within
the initrd. The rootfs is served on the slave through xnbd-server.

This setup is needed when the target system needs e.g.
extended file attributes like security labels to boot.
In this case cpio.gz and nfs do not work and both the initrd and
the rootfs need to be a full filesystem (e.g. ext4).

Boot sequence:
 DL -> tftp -> initrd (nbd-client+pivot_root) -> rootfs(nbd)

The implementation reuses as much as possible from the
existing tftp+nfs workflow. The startup of the xnbd-server
and its proper teardown required the use of an action/protocol
combination (similar to lxc).

The xnbd-server will use a random port (unless specified).
A helper function has been added to network.py.

A sample job might look like:
device_type: XYZ-uboot
job_name: simple Network Block Device (nbdroot) job

protocols:
  lava-xnbd:
    port: auto

actions:
- deploy:
    to: nbd
    dtb:
      url: 'http://127.0.0.1/uImage-bcm2710-rpi-3-b.dtb'
    kernel:
      url: 'http://127.0.0.1/uImage'
    initrd:
      url: 'http://127.0.0.1/initramfs-nbdboot.ext4.gz.u-boot'
      allow_modify: false
    nbdroot:
      url: 'http://127.0.0.1/rootfs.ext4.xz'
      compression: xz
    os: debian
    failure_retry: 2

- boot:
    method: u-boot
    commands: nbd
    type: bootm

TODO:
- documentation changes
- tests

Note:
The server side will require a few small changes to the schema.

v8 (jsmoeller): rebased to kernelci/lava-dispatcher branch release

v7 (jsmoeller): Fix comments and location of artifacts in testsuite.

v6 (jsmoeller): add test job, update bbb-01.yaml, add pipeline_ref

v5 (jsmoeller): rebased and adapted. docs in separate commit for lava-server.

v4 (jsmoeller): add OverlayAction to the nbd deploy strategy to allow
                transfer_overlay to work as we cannot apply the overlay before boot.

v3 (jsmoeller): forward-ported and fixed PEP issues.

v2 (jsmoeller): Fixed issues noted during review:
                - xnbd-server port comes now from range (defined in utils/constants.py)
                - timeout for xnbd protocol is in utils/constants.py
                - download/file suffix is now handled like tftp

v1 (jsmoeller): Initial version submitted as RFC for review/comments

Change-Id: Ibbaa10b4bdab49d9cc95d9b1c6cb3d67f848760a
Signed-off-by: Jan-Simon Möller <jsmoeller@linuxfoundation.org>